### PR TITLE
Added .gitignore file to prevent unnecessary files from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Node modules
+node_modules/
+npm-debug.log
+yarn.lock
+package-lock.json
+
+# Build files
+dist/
+build/
+.cache/
+
+# Environment variables
+.env
+.env.local
+.env.development
+.env.production
+.env.test
+
+# Logs
+*.log
+logs/
+debug.log
+
+# IDE and OS files
+.vscode/
+.DS_Store
+Thumbs.db
+
+# Next.js & Vite specific
+.next/
+out/
+.vite/


### PR DESCRIPTION
### Summary
This PR adds a `.gitignore` file to exclude unnecessary files from being tracked by Git. 

### Changes Made
- Created a `.gitignore` file.
- Added common files/folders to ignore, such as:
  - `node_modules/`
  - `.env`
  - `.DS_Store` (for macOS users)
  - `dist/` (for build outputs)
  - `.vscode/` (for VS Code settings)
  
### Why this is needed?
Ignoring unnecessary files improves repository cleanliness and prevents large or sensitive files from being committed. 

### Testing
Tested by running `git status` after adding the `.gitignore` file, ensuring that ignored files do not appear as untracked.
